### PR TITLE
test: add auth middleware unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "dev": "mastra dev",
     "build": "mastra build",
     "deploy": "mastra deploy",

--- a/src/mastra/middleware/auth.ts
+++ b/src/mastra/middleware/auth.ts
@@ -1,6 +1,6 @@
 import { MastraMiddleware } from "./type";
 
-const isDevelopment = () => {
+export const isDevelopment = () => {
   // 環境変数による判定
   if (process.env.NODE_ENV === "development") return true;
 

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import * as ts from 'typescript';
+
+const tsPath = new URL('../src/mastra/middleware/auth.ts', import.meta.url);
+const tsSource = readFileSync(tsPath, 'utf8');
+const jsSource = ts.transpileModule(tsSource, {
+  compilerOptions: { module: ts.ModuleKind.ES2022, target: ts.ScriptTarget.ES2022 }
+}).outputText;
+const moduleUrl = 'data:text/javascript;base64,' + Buffer.from(jsSource).toString('base64');
+const { isDevelopment } = await import(moduleUrl);
+
+test('returns true when NODE_ENV=development', () => {
+  process.env.NODE_ENV = 'development';
+  delete process.env.APP_URL;
+  assert.equal(isDevelopment(), true);
+});
+
+test('returns true when APP_URL port is 4111', () => {
+  process.env.NODE_ENV = 'production';
+  process.env.APP_URL = 'http://localhost:4111';
+  assert.equal(isDevelopment(), true);
+});
+
+test('returns false for production without dev port', () => {
+  process.env.NODE_ENV = 'production';
+  process.env.APP_URL = 'http://localhost:3000';
+  assert.equal(isDevelopment(), false);
+});


### PR DESCRIPTION
## Summary
- add a node test for isDevelopment helper
- export `isDevelopment` and wire npm test command

## Testing
- `npm test`